### PR TITLE
adjusting hero image behavior to prevent text overlap

### DIFF
--- a/assets/scss/article.scss
+++ b/assets/scss/article.scss
@@ -136,7 +136,7 @@
 }
 
 .article-hero-image{
-    position: absolute;
+    position: relative;
     z-index: 1;
     width: 100%;
     max-width: 944px;
@@ -149,7 +149,6 @@
 
     img{
         width: 100%;
-        max-height: 50vh;
     }
 
     /*DESKTOP MEDIUM*/

--- a/assets/scss/progress.scss
+++ b/assets/scss/progress.scss
@@ -4,10 +4,10 @@
     display: -ms-flexbox;
     display: flex;
     margin: 0 auto;
-    max-width: 1140px;
+    max-width: 20px;
     z-index: 0;
-    position: -webkit-sticky;
-    position: sticky;
+    position: -webkit-fixed;
+    position: fixed;
     top: 30%;
     -webkit-animation-name: progress-fade-in;
             animation-name: progress-fade-in;


### PR DESCRIPTION
Using fix from comments for issue forestryio/hugo-theme-novela#49 to replace viewport height hack